### PR TITLE
Add rule regarding ball play on the nearest neutral spot

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -208,11 +208,16 @@ or above their height), it is deemed damaged. (<<damaged-robots>>)
 on its convex hull within 10 seconds. If a robot does not do so within the time
 limit, it is deemed to be damaged.
 ~>Any robot must approach and touch the ball when it is placed on the nearest
-neutral spot before lack of progress is called. When on its own side of the field,
-any robot must be able to move the ball from the nearest neutral spot to the
-opponent's side of the field. If a robot does not do these things, it is deemed to be damaged.
-(See <<damaged-robots, Damaged Robots>>.) However, this rule does not apply if the robot
+neutral spot. It must do this before lack of progress is called. When on its
+own side of the field, any robot must be able to move the ball from the nearest
+neutral spot to the opponent's side of the field. If a robot does not do these
+things, referees may deem it damaged at their discretion.
+(See <<damaged-robots, Damaged Robots>>.) This rule does not apply if the robot
 is hindered from detecting or playing the ball by the opponent.~~}
+
+TIP: If placing the ball on a neutral spot would confer a gameplay advantage to
+one team or referees don't place the ball on the closest neutral spot for other
+reasons a robot is not required to approach the robot at further away neutral spots.
 
 [[scoring]]
 === Scoring

--- a/rules.adoc
+++ b/rules.adoc
@@ -206,8 +206,8 @@ or above their height), it is deemed damaged. (<<damaged-robots>>)
 
 {~~A robot must touch the ball that is placed no further than 20 cm from any point
 on its convex hull within 10 seconds. If a robot does not do so within the time
-limit, it is deemed to be damaged. ~>
-Any robot must approach and touch the ball when it is placed on the nearest
+limit, it is deemed to be damaged.
+~>Any robot must approach and touch the ball when it is placed on the nearest
 neutral spot before lack of progress is called. When on its own side of the field,
 any robot must be able to move the ball from the nearest neutral spot to the
 opponent's side of the field. If a robot does not do these things, it is deemed to be damaged.

--- a/rules.adoc
+++ b/rules.adoc
@@ -210,8 +210,8 @@ limit, it is deemed to be damaged.
 ~>Any robot must approach and touch the ball when it is placed on the nearest
 neutral spot. It must do this before lack of progress is called. When on its
 own side of the field, any robot must be able to move the ball from the nearest
-neutral spot to the opponent's side of the field. If a robot does not do these
-things, referees may deem it damaged at their discretion.
+neutral spot to the opponent's side of the field. If a specific robot does act
+this way, referees may deem it damaged at their discretion.
 (See <<damaged-robots, Damaged Robots>>.) This rule does not apply if the robot
 is hindered from detecting or playing the ball by the opponent.~~}
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -203,8 +203,6 @@ Other players must be able to access the ball.
 The ball needs to stay within the bounds of the field, as defined by the
 walls. If a robot moves the ball outside of the field (that is, beyond the walls
 or above their height), it is deemed damaged. (<<damaged-robots>>)
-<<<<<<< HEAD
-=======
 
 {~~A robot must touch the ball that is placed no further than 20 cm from any point
 on its convex hull within 10 seconds. If a robot does not do so within the time
@@ -215,7 +213,6 @@ any robot must be able to move the ball from the nearest neutral spot to the
 opponent's side of the field. If a robot does not do these things, it is deemed to be damaged.
 (See <<damaged-robots, Damaged Robots>>.) However, this rule does not apply if the robot
 is hindered from detecting or playing the ball by the opponent.~~}
->>>>>>> 32e1a77 (Add rule regarding ball play on the nearest neutral spot)
 
 [[scoring]]
 === Scoring

--- a/rules.adoc
+++ b/rules.adoc
@@ -203,6 +203,19 @@ Other players must be able to access the ball.
 The ball needs to stay within the bounds of the field, as defined by the
 walls. If a robot moves the ball outside of the field (that is, beyond the walls
 or above their height), it is deemed damaged. (<<damaged-robots>>)
+<<<<<<< HEAD
+=======
+
+{~~A robot must touch the ball that is placed no further than 20 cm from any point
+on its convex hull within 10 seconds. If a robot does not do so within the time
+limit, it is deemed to be damaged. ~>
+Any robot must approach and touch the ball when it is placed on the nearest
+neutral spot before lack of progress is called. When on its own side of the field,
+any robot must be able to move the ball from the nearest neutral spot to the
+opponent's side of the field. If a robot does not do these things, it is deemed to be damaged.
+(See <<damaged-robots, Damaged Robots>>.) However, this rule does not apply if the robot
+is hindered from detecting or playing the ball by the opponent.~~}
+>>>>>>> 32e1a77 (Add rule regarding ball play on the nearest neutral spot)
 
 [[scoring]]
 === Scoring
@@ -426,16 +439,12 @@ Robots must be constructed and programmed in a way that their movement is not
 limited to only one dimension (defined as a single axis, such as only moving in
 a straight line). They must move in all directions, for example by turning.
 
-Robots must respond to the ball in a direct forward movement towards it. For
+{--Robots must respond to the ball in a direct forward movement towards it. For
 example, it is not enough to basically just move left and right in front of
 their own goal, it must also move directly towards the ball in a forward
-movement. At least one team robot must be able to seek and approach the ball
+movement.--}At least one team robot must be able to seek and approach the ball
 anywhere on the field, unless the team has only one robot on the field at that
 time.
-
-A robot must touch the ball that is placed no further than 20 cm from any point
-on its convex hull within 10 seconds. If a robot does not do so within the time
-limit, it is deemed to be damaged. (See <<damaged-robots, Damaged Robots>>.)
 
 [[handle]]
 === Handle


### PR DESCRIPTION
### Please describe your change in one or two sentences

Add a rule regarding ball play: Robots must be able to approach and play a ball when it's placed on the nearest neutral spot. Also, when left alone, robots must be able to maneuver the ball to the opponents side of the field.

### Please explain why do you think this change should be in the rules

This new rule shall remove the ability of a goalie to simply block its own goal without leaving the goalie area.
