### PR TITLE
Note that the goal should not contain the wedge

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -500,7 +500,8 @@ of {~~25 cm in width~>12 cm in width~~}.
 
 The floor near the exterior wall includes a wedge, which is an incline with a
 10 cm base and 2 +/- 1 cm rise for allowing the ball to roll back into play
-when it leaves the playing field.
+when it leaves the playing field. Note that the goal should not contain the
+wedge.
 
 Total dimensions of the field, including the outer area, are 182 cm by 243 cm.
 

--- a/superteam_rules.adoc
+++ b/superteam_rules.adoc
@@ -332,7 +332,8 @@ each SuperTeam by a black line.
 
 The floor near the exterior wall includes a wedge, which is an incline with a
 10 cm base and 2 +/- 1 cm rise for allowing the ball to roll back into play
-when it leaves the playing field.
+when it leaves the playing field. Note that the goal should not contain the
+wedge.
 
 [[field-walls]]
 === Walls


### PR DESCRIPTION
### Please describe your change in one or two sentences

Just a note mentioning the goals should not contain the wedge in order to allow ball passing inside smoothly.

### Please explain why do you think this change should be in the rules

Last world RCJ all goals were mounted on top of the wedge, so it was probably not very clear.
