### PR TITLE
Add hint about rubrics and their importance

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -63,6 +63,11 @@ up to 3.0 cm{--, and may use batteries up to 12.0 V nominal voltage--}.
 ball. Robots may weigh up to 2.2 kg, may have a ball-capturing zone of up to
 1.5 cm{--, and may use batteries up to 15.0 V nominal voltage--}.
 
+IMPORTANT: A large part of the overall ranking is determined by the judged
+categories. These award points for documentation, design, innovation, achievement.
+Rubrics and other teams' documentation can be access through this forum thread:
+https://junior.forum.robocup.org/t/2024-awards-rubric-draft/3500
+
 Please see <<ball>> for ball specifications and <<league-regulations>> for
 more details for specifications/regulations.
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -63,7 +63,8 @@ up to 3.0 cm{--, and may use batteries up to 12.0 V nominal voltage--}.
 ball. Robots may weigh up to 2.2 kg, may have a ball-capturing zone of up to
 1.5 cm{--, and may use batteries up to 15.0 V nominal voltage--}.
 
-IMPORTANT: A large part of the overall ranking is determined by the judged
+IMPORTANT: A large part of the overall ranking (for the international tournament,
+ask you regional tournament organizers) is determined by the judged
 categories. These award points for documentation, design, innovation, achievement.
 Rubrics and other teams' documentation can be access through this forum thread:
 https://junior.forum.robocup.org/t/2024-awards-rubric-draft/3500


### PR DESCRIPTION
### Please describe your change in one or two sentences

Adding hint about rubrics and non-gameplay categories to be merged before release of final rules

### Please explain why do you think this change should be in the rules

As the final rules PDF is a document that gets not only linked to but also downloaded, forwarded, printed, reuploaded to regional tournament websites including the link now should help spread awareness of the judged categories.