### PR TITLE
Increasing & unifying kick power limit

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -1236,8 +1236,10 @@ The test is performed as follows:
 
 .  Place robot inside the left corner of a goal.
 .  Perform a kick into the opposing goal
-..  The Open League kicker power test is passed if after bouncing off of the opposite goal
+.  {~~The Open League kicker power test is passed if after bouncing off of the opposite goal
 the ball does not return further than the front line of to the penalty area
 it was shot from.
-..  The Light Weight League power test is passed if after bouncing off of the opposite goal
-the ball does not leave the penalty area of the opposing goal after bouncing back.
+The Light Weight League power test is passed if after bouncing off of the opposite goal
+the ball does not leave the penalty area of the opposing goal after bouncing back.~>The
+kick power test is passed if after bouncing off the opposite goal the ball does not
+hit the back wall of the own goal.~~}


### PR DESCRIPTION
### Please describe your change in one or two sentences

Increasing the kick power limit for both Lightweight and Open League to slightly more than the current Open League Limit. Note that this will be subject to real testing in the coming weeks and may be changed.

### Please explain why do you think this change should be in the rules

The new on-field kick power test on some materials resulted in less kick power for Lightweight League. Creating a unified power limit would also ease complexity of rule & testing procedure