### PR TITLE
Moving communications module rule from Superteam to main rules.

### DIFF
--- a/superteam_rules.adoc
+++ b/superteam_rules.adoc
@@ -1,4 +1,4 @@
-= RoboCupJunior Soccer SuperTeam Rules 2024
+= RoboCupJunior Soccer SuperTeam Rules 2025
 {docdate}
 :toc: left
 :sectanchors:
@@ -17,7 +17,7 @@ endif::basebackend-html[]
 :icons: font
 :numbered:
 
-These are the draft SuperTeam Soccer rules for RoboCupJunior 2024. They are
+These are the draft SuperTeam Soccer rules for RoboCupJunior 2025. They are
 released by the RoboCupJunior Soccer League Committee. The English version
 of these rules has priority over any translations.
 
@@ -54,6 +54,18 @@ been analyzed and are ruled here. For all other situations that do not change
 from the regular game rules, normally they have been only mentioned here as
 being the same regular game rule.**
 
+[discrete]
+=== Changes from the 2024 RoboCupJunior Soccer SuperTeam Rules
+
+// TODO: Summarize changes here
+The rule changes developed by the Soccer League Committee in cooperation with the
+RoboCup Junior Soccer Community (please continue to post ideas for the future on
+the forum any time) aim to improve gameplay.
+
+Detailed changes are listed below and link to the corresponding place in the rule.
+
+{+-~TOC-CHANGES~-+}
+
 [[gameplay]]
 == GAMEPLAY
 
@@ -79,11 +91,11 @@ difference between the losing and the winning team.
 
 [[tournament-mode-byes]]
 === Tournament mode and Bye games
-{++In some cases (e.g. uneven number of teams) not every team can play every round.
+In some cases (e.g. uneven number of teams) not every team can play every round.
 In threse cases the team that is free from play is awarded a Bye. In SuperTeam
 matches where fewer goals are scored the Bye is awarded as a 3:0 victory instead
 of the usual 10:0. Contact your regional/super-regional tournament organizers for
-details at tournaments other than the international RoboCupJunior tournament.++}
+details at tournaments other than the international RoboCupJunior tournament.
 
 [[pre-match-meeting]]
 === Pre-match meeting
@@ -294,7 +306,7 @@ link:https://robocup-junior.github.io/soccer-rules/master/rules.html[RoboCupJuni
 
 link:https://robocup-junior.github.io/soccer-rules/master/rules.html[RoboCupJunior Soccer Rules] rule <<communication>> applies.
 
-To make SuperTeam games more manageable at present and make
+{~~To make SuperTeam games more manageable at present and make
 communication between multiple robots in a SuperTeam easier in the future, the
 Soccer League Committee will provide each team with a communication module. Each
 team will be expected to interface with this module using a single 2.54mm GPIO
@@ -302,6 +314,7 @@ pin at present and the Soccer League Committee plans on extending this to using
 UART or I²C for more complex applications in future years.
 
 More details will be provided by the Soccer League Committee before the competition.
+~>Communication module rule moved to main rules.~~}
 
 [[agility]]
 === Agility


### PR DESCRIPTION
### Please describe your change in one or two sentences

Updating SuperTeams document for 2025 season. Changing Communication Module requirement rule from SuperTeam only to all competition.

### Please explain why do you think this change should be in the rules

Providing better game play with referee control of the robots.
