### PR TITLE
Add community discord and email reachability to rules doc

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -34,6 +34,13 @@ https://robocup-junior.github.io/soccer-rules/master/rules.html in HTML form
 and at https://robocup-junior.github.io/soccer-rules/master/rules.pdf in PDF
 form.]
 
+TIP: Teams are encouraged to get in touch with the RoboCupJunior community on
+our Discord. Show what you're working on, ask questions or join the weekly
+discussions on future rules and league design. You can join the server at
+https://robocup-junior.github.io/soccer-rules/discord/
+You can also reach the Soccer League Committee directly via email at
+robocupjunior-soccer [ at ] robocup [ dot ] org
+
 [title="Two teams of two robots with an orange ball on a RoboCupJunior Soccer field."]
 image::media/field_with_two_teams.jpg[]
 

--- a/superteam_rules.adoc
+++ b/superteam_rules.adoc
@@ -34,6 +34,13 @@ https://robocup-junior.github.io/soccer-rules/master/superteam_rules.html in HTM
 and at https://robocup-junior.github.io/soccer-rules/master/superteam_rules.pdf in PDF
 form.]
 
+TIP: Teams are encouraged to get in touch with the RoboCupJunior community on
+our Discord. Show what you're working on, ask questions or join the weekly
+discussions on future rules and league design. You can join the server at
+https://robocup-junior.github.io/soccer-rules/discord/
+You can also reach the Soccer League Committee directly via email at
+robocupjunior-soccer [ at ] robocup [ dot ] org
+
 [discrete]
 == Preface
 


### PR DESCRIPTION
### Please describe your change in one or two sentences

As we spoke about in the meeting this adds contact email and discord in an info-box at the top of the rules

### Please explain why do you think this change should be in the rules

See meeting notes