### PR TITLE
2025 soccer draft rules global rules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,9 @@ jobs:
     name: build
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: build the rules
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "general-rules"]
+	path = general-rules
+	url = git@github.com:robocup-junior/general-rules.git

--- a/preamble.tex
+++ b/preamble.tex
@@ -86,6 +86,7 @@
   \fancyhf{}
   \fancyfoot[L]{\textit{Draft rules as of \today}}
   \fancyfoot[R]{Page \textbf{\thepage} of \textbf{\pageref{LastPage}}}
+  \fancyhead[R]{\includegraphics[width=8cm]{media/image15.png}}
 }
 
 \title{\vspace{-5ex}RoboCupJunior Soccer Rules 2025\vspace{-5ex}}
@@ -101,8 +102,8 @@
 
 
 \begin{document}
-\maketitle
 \thispagestyle{firststyle}
+\maketitle
 
 \begin{center}
 \begin{tabular}{cc}

--- a/rules.adoc
+++ b/rules.adoc
@@ -17,7 +17,7 @@ endif::basebackend-html[]
 :icons: font
 :numbered:
 
-These are the Soccer rules for RoboCupJunior 2024. They are released
+These are the Soccer rules for RoboCupJunior 2025. They are released
 by the RoboCupJunior Soccer League Committee. The English version of these
 rules has priority over any translations.
 
@@ -78,7 +78,7 @@ organizer of your regional RoboCupJunior competition and ask them about_ <<entry
 Unless specified otherwise, all parts of these rules are released under the
 terms of the Creative Commons Attribution-ShareAlike License.
 
-[discrete]
+[[general-rules]]
 include::general-rules/general-rules.adoc[]
 
 [discrete]

--- a/rules.adoc
+++ b/rules.adoc
@@ -78,6 +78,8 @@ organizer of your regional RoboCupJunior competition and ask them about_ <<entry
 Unless specified otherwise, all parts of these rules are released under the
 terms of the Creative Commons Attribution-ShareAlike License.
 
+include::general-rules/general-rules.adoc[]
+
 [discrete]
 === Changes from the 2024 RoboCupJunior Soccer Rules
 

--- a/rules.adoc
+++ b/rules.adoc
@@ -78,6 +78,7 @@ organizer of your regional RoboCupJunior competition and ask them about_ <<entry
 Unless specified otherwise, all parts of these rules are released under the
 terms of the Creative Commons Attribution-ShareAlike License.
 
+[discrete]
 include::general-rules/general-rules.adoc[]
 
 [discrete]


### PR DESCRIPTION
### Please describe your change in one or two sentences

Add the Global Rules as a submodule of its repository (https://github.com/robocup-junior/general-rules) and include it in the rule text (via the `include` command).

### Please explain why do you think this change should be in the rules

To make sure the General Rules are included inside the text of the soccer rules.