### PR TITLE
open league remove weight limit

### DIFF
--- a/rules.adoc
+++ b/rules.adoc
@@ -665,7 +665,7 @@ robot’s dimensions must not exceed the following limits:
 |sub-league | *Soccer* *Open* | *Soccer Lightweight*
 |size ^[0]^  | 18.0 cm | 22.0 cm +
 |height | 18.0 cm ^[1]^ | 22.0 cm ^[1]^ +
-|weight | 2200 g ^[2]^ | 1400 g ^[2]^ +
+|weight | {~~2200 g~>No limit~~} ^[2]^ | 1400 g ^[2]^ +
 |ball-capturing zone | 1.5 cm | 3.0 cm +
 |voltage | 48V DC / 25V AC RMS ^[3]^ ^[4]^ +
 |===


### PR DESCRIPTION
### Please describe your change in one or two sentences

Removing the 2200g weight limit on open league

### Please explain why do you think this change should be in the rules

An increase of the weight limit of OL has been discussed at RCJ 2024 in Eindhoven as well as [on the forum](https://junior.forum.robocup.org/t/higher-soccer-open-weight-limit-proposal/3958/5) but we had not gone forward with it because the weight of OL robots was far away from 2200g. Teams have asked again because they now have concrete designs that the weight limit would be a problem for. So after discussing wether this would cause any issues we came to the conclusion that the risk is low enough that we can enable whatever new design that might be forthcoming because most teams are already not constrained by the limit (In Eindhoven the average robot weight was ~600g below the limit). 